### PR TITLE
Update the MergeLink type so the Team Chain can be sent via Automerge

### DIFF
--- a/src/chain/types.ts
+++ b/src/chain/types.ts
@@ -67,7 +67,7 @@ export type MergeLink = {
   hash: Hash
 
   /** Hashes of the two concurrent heads being merged */
-  body: [Hash, Hash]
+  body: Hash[]
 }
 
 export type RootLink<A extends Action> = SignedLink<RootLinkBody<A>, A>


### PR DESCRIPTION
With this change an `Automerge.FreezeObject<TeamSignatureChain>>` can be given as the argument to a `Team.merge()`.

This allows people to use Automerge to transfer chain updates between nodes without writing special logic to determine which links are new and having users create `MergeLink` nodes explicitly.

Also, the `DeviceType` and `TeamSignatureChain` types are not publicly exported but it might be useful to do so.

```ts
import 'localstorage-polyfill'
import Automerge from 'automerge'
import Auth from '@localfirst/auth'
import { assert, TeamSignatureChain } from './types'

// Automerge does not like undefined values so remove them
function removeUndefinedValues<T>(obj: any) {
  return JSON.parse(JSON.stringify(obj)) as T
}

const userConfig = {
  deviceName: 'Laptop',
  deviceType: 1, // DeviceType.laptop,
  seed: 'passw0rd'
}
const alice = Auth.createUser({...userConfig, userName: 'Alice'})
const bob   = Auth.createUser({...userConfig, userName: 'Bob'})

const aliceTeam = Auth.createTeam('dream', {user: alice})
let aliceDoc: Automerge.FreezeObject<TeamSignatureChain> = Automerge.from(removeUndefinedValues(aliceTeam.chain))

// This listener updates aliceDoc whenever the chain in aliceTeam updates
aliceTeam.addListener('updated', ({head:headId}) => {
  const event = aliceTeam.chain.links[headId]
  aliceDoc = Automerge.change(aliceDoc, (d) => {
    d.links[headId] = removeUndefinedValues(event)
    d.head = headId
  })
})

// Invite Bob and admit them into the team
const {invitationSeed} = aliceTeam.invite('Bob')
const proof = Auth.generateProof(invitationSeed, 'Bob')
aliceTeam.admit(proof)

// Send Bob the team membership history (Automerge Doc)
const bobTeam = new Auth.Team({
  source: aliceDoc,
  context: {user: bob}
})

// Alice sends their chain to Bob so he can initialize it
let bobDoc = aliceDoc
// This listener is the same as for aliceTeam+aliceDoc.
// It updates bobDoc whenever the chain in bobTeam updates
bobTeam.addListener('updated', ({head:headId}) => {
  const event = bobTeam.chain.links[headId]
  bobDoc = Automerge.change(bobDoc, (d) => {
    d.links[headId] = removeUndefinedValues(event)
    d.head = headId
  })
})

bobTeam.join(proof)

// Merge Bob's new keys into Alice's chain
// Confirm that merging Bob's chain into Alice's makes them the same
assert(bobDoc.head !== aliceDoc.head)
aliceTeam.merge(bobDoc)
assert(bobDoc.head === aliceDoc.head)
```