### PR TITLE
Ask to resend missing messages

### DIFF
--- a/packages/auth/src/connection/message.ts
+++ b/packages/auth/src/connection/message.ts
@@ -13,6 +13,13 @@ export type DisconnectMessage = {
   }
 }
 
+export type RequestResendMessage = {
+  type: 'REQUEST_RESEND'
+  payload: {
+    index: number
+  }
+}
+
 // Identity
 
 export type ClaimIdentityMessage = {
@@ -96,3 +103,4 @@ export type ConnectionMessage =
   | ReadyMessage
   | SeedMessage
   | SyncMessage
+  | RequestResendMessage

--- a/packages/auth/src/connection/test/connection.test.ts
+++ b/packages/auth/src/connection/test/connection.test.ts
@@ -24,4 +24,29 @@ describe('connection', () => {
 
     await all([aliceConnection, bobConnection], 'connected')
   })
+
+  it('should connect even when messages are dropped', () => {
+    const { alice, bob } = setup('alice', 'bob')
+
+    const join = joinTestChannel(new BadChannel()) // <- BadChannel drops messages
+
+    const aliceConnection = join(alice.connectionContext).start()
+    const bobConnection = join(bob.connectionContext).start()
+
+    return all([aliceConnection, bobConnection], 'connected')
+  })
 })
+
+import { EventEmitter } from 'eventemitter3'
+
+/**
+ * This channel is like TestChannel but it drops one message
+ */
+export class BadChannel extends TestChannel {
+  private messageCount = 0
+  write(senderId: string, message: Uint8Array) {
+    this.messageCount++
+    if (this.messageCount === 3) return // <- drop the third message we see
+    super.write(senderId, message)
+  }
+}


### PR DESCRIPTION
This PR builds on the work in #85 to use the `OrderedNetwork`'s facility for requesting and resending missed messages in the `Connection`.

- adds a `REQUEST_RESEND` message type with an `index` on the payload
- handles `REQUEST_RESEND` messages from our peer by resending the requested message
- sends a `REQUEST_RESEND` message to our peer when the `OrderedNetwork` emits a `request` event
