### PR TITLE
Preserve device info

### DIFF
--- a/packages/auth/src/connection/test/authentication.test.ts
+++ b/packages/auth/src/connection/test/authentication.test.ts
@@ -167,6 +167,25 @@ describe('connection', () => {
         expect(() => bob.team.teamKeys()).not.toThrow()
       })
 
+      it('after an invitee is admitted, the device recorded on the team includes user-agent metadata', async () => {
+        const { alice, bob } = setup('alice', { user: 'bob', member: false })
+
+        // 👩🏾📧👨🏻‍🦲 Alice invites Bob
+        const { seed } = alice.team.inviteMember()
+
+        // 👨🏻‍🦲📧<->👩🏾 Bob connects to Alice and uses his invitation to join
+        await connectWithInvitation(alice, bob, seed)
+
+        // Update the team from the connection
+        const connection = bob.connection[alice.deviceId]
+        bob.team = connection.team!
+
+        // 👨🏻‍🦲 Bob's device was recorded with user-agent metadata
+        const { deviceId } = bob.device
+        const device = bob.team.device(deviceId)
+        expect(device?.deviceInfo).toEqual(bob.device.deviceInfo)
+      })
+
       it("doesn't allow two invitees to connect", async () => {
         const { alice, charlie, dwight } = setup([
           'alice',

--- a/packages/auth/src/device/redact.ts
+++ b/packages/auth/src/device/redact.ts
@@ -5,5 +5,6 @@ export const redactDevice = (device: DeviceWithSecrets): Device => ({
   userId: device.userId,
   deviceId: device.deviceId,
   deviceName: device.deviceName,
+  deviceInfo: device.deviceInfo,
   keys: redactKeys(device.keys),
 })

--- a/packages/auth/src/team/test/createTeam.test.ts
+++ b/packages/auth/src/team/test/createTeam.test.ts
@@ -57,5 +57,16 @@ describe('Team', () => {
       alice.team.setTeamName(`Sgt. Pepper's Lonely Hearts Club Band`)
       expect(alice.team.teamName).toBe(`Sgt. Pepper's Lonely Hearts Club Band`)
     })
+
+    it('the team preserves device metadata if provided', () => {
+      const user = createUser('alice')
+      const device = createDevice({
+        userId: user.userId,
+        deviceName: 'laptop',
+        deviceInfo: { foo: 'bar' },
+      })
+      const team = createTeam('Spies Я Us', { user, device })
+      expect(team.device(device.deviceId).deviceInfo.foo).toBe('bar')
+    })
   })
 })

--- a/packages/auth/src/util/testing/constants.ts
+++ b/packages/auth/src/util/testing/constants.ts
@@ -1,0 +1,15 @@
+export const laptopInfo = {
+  ua: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36',
+  browser: { name: 'Chrome', version: '124.0.0.0', major: '124' },
+  engine: { name: 'Blink', version: '124.0.0.0' },
+  os: { name: 'Mac OS', version: '10.15.7' },
+  device: { vendor: 'Apple', model: 'Macintosh' },
+}
+
+export const phoneInfo = {
+  ua: 'Mozilla/5.0 (iPhone; CPU iPhone OS 17_4_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.4.1 Mobile/15E148 Safari/604.1',
+  browser: { name: 'Mobile Safari', version: '17.4.1', major: '17' },
+  engine: { name: 'WebKit', version: '605.1.15' },
+  os: { name: 'iOS', version: '17.4.1' },
+  device: { vendor: 'Apple', model: 'iPhone', type: 'mobile' },
+}

--- a/packages/auth/src/util/testing/setup.ts
+++ b/packages/auth/src/util/testing/setup.ts
@@ -9,6 +9,7 @@ import type { LocalUserContext } from 'team/context.js'
 import type { Team, TeamContext } from 'team/index.js'
 import * as teams from 'team/index.js'
 import { arrayToMap } from 'util/index.js'
+import { phoneInfo, laptopInfo } from './constants.js'
 
 export type SetupConfig = Array<Array<TestUserSettings | string> | TestUserSettings | string>
 
@@ -51,7 +52,8 @@ export const setup = (..._config: SetupConfig) => {
   const makeDevice = (userId: string, deviceName: string) => {
     const key = `${userId}-${deviceName}`
     const randomSeed = key
-    const device = devices.createDevice({ userId, deviceName, seed: randomSeed })
+    const deviceInfo = deviceName === 'phone' ? phoneInfo : laptopInfo
+    const device = devices.createDevice({ userId, deviceName, seed: randomSeed, deviceInfo })
     return device
   }
 


### PR DESCRIPTION
As of c442a95117d68836dbb7c7a8596bcf7bd82e1cb9 we allow providing arbitrary metadata (`device.deviceInfo`) when creating a device. For example XDev uses this to store information parsed from the UA string. 

However this info wasn't surviving a round trip through the Team graph because `redactDevice` didn't include `deviceInfo` in the redacted object returned. This fixes that omission and adds tests. 

