### PR TITLE
Stop hard-coding 'http' protocol for sync server interactions in AuthProvider.ts

### DIFF
--- a/packages/auth-provider-automerge-repo/src/AuthProvider.ts
+++ b/packages/auth-provider-automerge-repo/src/AuthProvider.ts
@@ -11,6 +11,7 @@ import { hash } from '@localfirst/crypto'
 import { debug, memoize, pause } from '@localfirst/shared'
 import { type AbstractConnection } from 'AbstractConnection.js'
 import { AnonymousConnection } from 'AnonymousConnection.js'
+import { buildServerUrl } from 'buildServerUrl.js'
 import { getShareId } from 'getShareId.js'
 import { pack, unpack } from 'msgpackr'
 import { isJoinMessage, type JoinMessage } from 'types.js'
@@ -229,7 +230,7 @@ export class AuthProvider extends EventEmitter<AuthProviderEvents> {
     await this.addTeam(team)
 
     const registrations = this.#server.map(async server => {
-      const { origin, hostname } = this.#parseServer(server)
+      const { origin, hostname } = buildServerUrl(server)
 
       // get the server's public keys
       const response = await fetch(`${origin}/keys`)
@@ -335,7 +336,7 @@ export class AuthProvider extends EventEmitter<AuthProviderEvents> {
    */
   public async registerPublicShare(shareId: ShareId) {
     const registrations = this.#server.map(async server => {
-      const { origin } = this.#parseServer(server)
+      const { origin } = buildServerUrl(server)
 
       await fetch(`${origin}/public-shares`, {
         method: 'POST',
@@ -397,14 +398,6 @@ export class AuthProvider extends EventEmitter<AuthProviderEvents> {
   }
 
   // PRIVATE
-
-  #parseServer(server: string) {
-    // assume http if no protocol provided (for backwards compatibility)
-    if (!server.includes('//')) {
-      server = `http://${server}`
-    }
-    return new URL(server)
-  }
 
   /**
    * We might get messages from a peer before we've set up an Auth.Connection with them.

--- a/packages/auth-provider-automerge-repo/src/AuthProvider.ts
+++ b/packages/auth-provider-automerge-repo/src/AuthProvider.ts
@@ -232,15 +232,16 @@ export class AuthProvider extends EventEmitter<AuthProviderEvents> {
       // url could be "localhost:3000" or "syncserver.example.com"
       const host = url.split(':')[0] // omit port
 
+      const protocol = this.#getHttpProtocol(url)
       // get the server's public keys
-      const response = await fetch(`http://${url}/keys`)
+      const response = await fetch(`${protocol}://${url}/keys`)
       const keys = await response.json()
 
       // add the server's public keys to the team
       team.addServer({ host, keys })
 
       // register the team with the server
-      await fetch(`http://${url}/teams`, {
+      await fetch(`${protocol}://${url}/teams`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
@@ -336,7 +337,8 @@ export class AuthProvider extends EventEmitter<AuthProviderEvents> {
    */
   public async registerPublicShare(shareId: ShareId) {
     const registrations = this.#server.map(async url => {
-      await fetch(`http://${url}/public-shares`, {
+      const protocol = this.#getHttpProtocol(url)
+      await fetch(`${protocol}://${url}/public-shares`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ shareId }),
@@ -396,6 +398,13 @@ export class AuthProvider extends EventEmitter<AuthProviderEvents> {
   }
 
   // PRIVATE
+
+  /**
+   * Use http for localhost but https for anything else
+   */
+  #getHttpProtocol(url: string) {
+    return url?.includes('localhost') ? 'http' : 'https'
+  }
 
   /**
    * We might get messages from a peer before we've set up an Auth.Connection with them.

--- a/packages/auth-provider-automerge-repo/src/buildServerUrl.ts
+++ b/packages/auth-provider-automerge-repo/src/buildServerUrl.ts
@@ -1,0 +1,10 @@
+/**
+ * Prepends the given host with protocol if it's missing, and returns a URL object.
+ */
+export const buildServerUrl = (host: string) => {
+  // assume http if no protocol provided (for backwards compatibility)
+  if (!host.includes('//')) {
+    host = `http://${host}`
+  }
+  return new URL(host)
+}

--- a/packages/auth-provider-automerge-repo/src/test/buildServerUrl.test.ts
+++ b/packages/auth-provider-automerge-repo/src/test/buildServerUrl.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest'
+import { buildServerUrl } from '../buildServerUrl.js'
+
+describe('buildServerUrl', () => {
+  it('should prepend http:// when no protocol is provided', () => {
+    const { protocol, hostname } = buildServerUrl('example.com')
+    expect(protocol).toBe('http:')
+    expect(hostname).toBe('example.com')
+  })
+
+  it('should not prepend http:// when https protocol is provided', () => {
+    const { protocol, hostname } = buildServerUrl('https://example.com')
+    expect(protocol).toBe('https:')
+    expect(hostname).toBe('example.com')
+  })
+
+  it('should not prepend http:// when http protocol is provided', () => {
+    const { protocol, hostname } = buildServerUrl('http://example.com')
+    expect(protocol).toBe('http:')
+    expect(hostname).toBe('example.com')
+  })
+
+  it('should handle hosts with ports', () => {
+    const { protocol, hostname, port } = buildServerUrl('example.com:8080')
+    expect(protocol).toBe('http:')
+    expect(hostname).toBe('example.com')
+    expect(port).toBe('8080')
+  })
+
+  it('should handle localhost', () => {
+    const { protocol, hostname, port } = buildServerUrl('localhost:3000')
+    expect(protocol).toBe('http:')
+    expect(hostname).toBe('localhost')
+    expect(port).toBe('3000')
+  })
+})


### PR DESCRIPTION
### Solves

We're unable to properly connect to sync servers hosted with TLS because the `AuthProvider` is always trying to make certain requests using `http://`.

### Description

I've added a private method in `AuthProvider.ts` to determine which protocol to use based on the given server url we're working with. In this case I'm making a simple check that returns "http" if the url contains "localhost" and otherwise defaults to "https".

