### PR TITLE
Add error handling to the Connection state machine

### DIFF
--- a/packages/auth/src/connection/Connection.ts
+++ b/packages/auth/src/connection/Connection.ts
@@ -24,6 +24,7 @@ import {
   TIMEOUT,
   createErrorMessage,
   type ConnectionErrorType,
+  UNHANDLED,
 } from 'connection/errors.js'
 import { getDeviceUserFromGraph } from 'connection/getDeviceUserFromGraph.js'
 import * as identity from 'connection/identity.js'
@@ -701,7 +702,8 @@ export class Connection extends EventEmitter<ConnectionEvents> {
         this.#log(`⏩ ${summary} `)
       },
       error: error => {
-        console.error('Connection encountered an error', error)
+        console.error('Connection encountered an unhandled error', error)
+        this.#fail(UNHANDLED)
       },
     })
 

--- a/packages/auth/src/connection/Connection.ts
+++ b/packages/auth/src/connection/Connection.ts
@@ -694,10 +694,15 @@ export class Connection extends EventEmitter<ConnectionEvents> {
     this.#machine = createActor(machine)
 
     // emit and log all transitions
-    this.#machine.subscribe(state => {
-      const summary = stateSummary(state.value as string)
-      this.emit('change', summary)
-      this.#log(`⏩ ${summary} `)
+    this.#machine.subscribe({
+      next: state => {
+        const summary = stateSummary(state.value as string)
+        this.emit('change', summary)
+        this.#log(`⏩ ${summary} `)
+      },
+      error: error => {
+        console.error('Connection encountered an error', error)
+      },
     })
 
     // add automatic logging to all events

--- a/packages/auth/src/connection/errors.ts
+++ b/packages/auth/src/connection/errors.ts
@@ -8,6 +8,7 @@ export const MEMBER_REMOVED = 'MEMBER_REMOVED' as const
 export const NEITHER_IS_MEMBER = 'NEITHER_IS_MEMBER' as const
 export const SERVER_REMOVED = 'SERVER_REMOVED' as const
 export const TIMEOUT = 'TIMEOUT' as const
+export const UNHANDLED = 'UNHANDLED' as const
 
 export const connectionErrors: Record<string, ErrorDefinition> = {
   [DEVICE_REMOVED]: {
@@ -47,6 +48,9 @@ export const connectionErrors: Record<string, ErrorDefinition> = {
   [TIMEOUT]: {
     localMessage: "We didn't hear back from the peer; giving up",
     remoteMessage: "The peer didn't hear back from you, so they gave up",
+  },
+  [UNHANDLED]: {
+    localMessage: 'An unhandled error occurred',
   },
 }
 


### PR DESCRIPTION
### Solves

Unexpected errors that occur in the state machine within `Connection.ts` are not handled and can completely crash a sync server when they're encountered.

### Description

This adds  a simple error listener when we subscribe to the state machine Actor so that we can at least log the error the host console. This also seems to prevent the hard crash that brings down the running sync server process.
