### PR TITLE
crypto tests: import everything from index

### DIFF
--- a/packages/crypto/src/test/asymmetric.test.ts
+++ b/packages/crypto/src/test/asymmetric.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect } from 'vitest'
-import { signatures, asymmetric } from '..'
+import { signatures, asymmetric } from '../index.js'
 
 const { keyPair, encryptBytes, decryptBytes, encrypt, decrypt } = asymmetric
 

--- a/packages/crypto/src/test/hash.test.ts
+++ b/packages/crypto/src/test/hash.test.ts
@@ -1,6 +1,6 @@
 import { pack } from 'msgpackr'
 import { describe, expect, it } from 'vitest'
-import { hash, hashBytes } from '..'
+import { hash, hashBytes } from '../index.js'
 import { base58, keyToBytes } from '../util/index.js'
 
 describe('crypto', () => {

--- a/packages/crypto/src/test/randomKey.test.ts
+++ b/packages/crypto/src/test/randomKey.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { randomKey, randomKeyBytes } from '../randomKey.js'
+import { randomKey, randomKeyBytes } from '../index.js'
 
 describe('randomKey', () => {
   it('should return keys of the expected length', () => {

--- a/packages/crypto/src/test/signatures.test.ts
+++ b/packages/crypto/src/test/signatures.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'vitest'
-import { asymmetric, randomKey, signatures } from '..'
+import { asymmetric, randomKey, signatures } from '../index.js'
 import { type Base58, type SignedMessage } from '../types.js'
 
 const { keyPair, sign, verify } = signatures

--- a/packages/crypto/src/test/stretch.test.ts
+++ b/packages/crypto/src/test/stretch.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'vitest'
-import { stretch } from '../stretch.js'
+import { stretch } from '../index.js'
 import { base58 } from '../util/index.js'
 
 describe('stretch', () => {


### PR DESCRIPTION
libsodium has an async initialization step, which we deal with using a top-level await in the crypto package's main export: 

https://github.com/local-first-web/auth/blob/573c17e1fa24fd0499981041606e74952721201a/packages/crypto/src/index.ts#L3

But some tests were importing directly from the individual modules, e.g.

https://github.com/local-first-web/auth/blob/1463003ad7bb8a2b584d231b0171ddeaaf2d46ff/packages/crypto/src/test/randomKey.test.ts#L2

and this was causing a race condition that resulted in intermittent test failures in the crypto package. 

This PR ensures that all tests import from `../index.js` so that libsodium is always initialized before we try to use it. 


### Testing plan

Confirm that the crypto tests consistently pass