### PR TITLE
Stop passing a peerId when creating a Repo

### DIFF
--- a/packages/auth-syncserver/src/SyncServer.ts
+++ b/packages/auth-syncserver/src/SyncServer.ts
@@ -1,4 +1,4 @@
-import { Repo, type PeerId } from '@automerge/automerge-repo'
+import { Repo } from '@automerge/automerge-repo'
 import { NodeWSServerAdapter } from '@automerge/automerge-repo-network-websocket'
 import { NodeFSStorageAdapter } from '@automerge/automerge-repo-storage-nodefs'
 import {
@@ -85,14 +85,12 @@ export class LocalFirstAuthSyncServer {
       const server: ServerWithSecrets = { host: this.host, keys }
       const user = castServer.toUser(server)
       const device = castServer.toDevice(server)
-      const peerId = this.host as PeerId
       const storage = new NodeFSStorageAdapter(storageDir)
       const auth = new AuthProvider({ user, device, storage })
 
       // Set up the repo
       const adapter = new NodeWSServerAdapter(this.webSocketServer)
       const _repo = new Repo({
-        peerId,
         // Use the auth provider to wrap our network adapter
         network: [auth.wrap(adapter)],
         // Use the same storage that the auth provider uses

--- a/packages/auth-syncserver/src/test/SyncServer.test.ts
+++ b/packages/auth-syncserver/src/test/SyncServer.test.ts
@@ -34,7 +34,7 @@ it('Alice can create a team', async () => {
 
   // when we're authenticated, we get a peer event
   const { peerId } = await eventPromise(alice.repo.networkSubsystem, 'peer')
-  expect(peerId?.length).toBeGreaterThan(0)
+  expect(peerId.length).toBeGreaterThan(0)
 })
 
 it('Alice can create a team and manually register it with the server ', async () => {
@@ -68,7 +68,7 @@ it('Alice can create a team and manually register it with the server ', async ()
 
   // when we're authenticated, we get a peer event
   const { peerId } = await eventPromise(alice.repo.networkSubsystem, 'peer')
-  expect(peerId?.length).toBeGreaterThan(0)
+  expect(peerId.length).toBeGreaterThan(0)
 })
 
 // // TODO NEXT figure out how to make this test reflect reality & crash

--- a/packages/auth-syncserver/src/test/SyncServer.test.ts
+++ b/packages/auth-syncserver/src/test/SyncServer.test.ts
@@ -34,7 +34,7 @@ it('Alice can create a team', async () => {
 
   // when we're authenticated, we get a peer event
   const { peerId } = await eventPromise(alice.repo.networkSubsystem, 'peer')
-  expect(peerId).toEqual(host)
+  expect(peerId?.length).toBeGreaterThan(0)
 })
 
 it('Alice can create a team and manually register it with the server ', async () => {
@@ -68,7 +68,7 @@ it('Alice can create a team and manually register it with the server ', async ()
 
   // when we're authenticated, we get a peer event
   const { peerId } = await eventPromise(alice.repo.networkSubsystem, 'peer')
-  expect(peerId).toEqual(host)
+  expect(peerId?.length).toBeGreaterThan(0)
 })
 
 // // TODO NEXT figure out how to make this test reflect reality & crash
@@ -131,8 +131,7 @@ it(`Eve can't replace the team on the sync server`, async () => {
     body: JSON.stringify({ serializedGraph, teamKeyring }),
   })
 
-  const { peerId } = await eventPromise(alice.repo.networkSubsystem, 'peer')
-  expect(peerId).toEqual(host)
+  await eventPromise(alice.repo.networkSubsystem, 'peer')
 
   // Eve tries to re-register the team with the server
 


### PR DESCRIPTION
We've come to realize that we should let `automerge-repo` manage the `peerId` for each instance of `Repo`. This updates the `LocalFirstAuthSyncServer` to stop passing a `peerId` when creating its `Repo`.