### PR TITLE
Improve performance of memoized validator functions.

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "test:pw": "pnpm -F @localfirst/automerge-repo-todos test:pw",
     "test:pw:log": "pnpm -F @localfirst/automerge-repo-todos test:pw:log",
     "test:pw:ui": "pnpm -F @localfirst/automerge-repo-todos test:pw:ui",
+    "bench": "cross-env DEBUG=localfirst*,automerge* DEBUG_COLORS=1 vitest bench",
     "watch": "lerna watch -- lerna run build --scope=\\$LERNA_PACKAGE_NAME --include-dependents"
   },
   "devDependencies": {

--- a/packages/auth/src/test/auth.benchmark.ts
+++ b/packages/auth/src/test/auth.benchmark.ts
@@ -1,0 +1,45 @@
+import { describe, bench } from 'vitest'
+import * as Auth from '../index.js'
+
+describe('auth', () => {
+  bench('a new member joining', () => {
+    const founderUsername = 'founder'
+    const founderContext = {
+      user: Auth.createUser(founderUsername, founderUsername),
+      device: Auth.createDevice({ userId: founderUsername, deviceName: 'laptop' }),
+    }
+    const teamName = 'Test'
+    const team = Auth.createTeam(teamName, founderContext)
+
+    //
+    // Add 100 test users
+    //
+
+    const usernames = [...new Array(100).keys()].map(i => 'user-' + i)
+
+    for (const username of usernames) {
+      const user = Auth.createUser(username, username)
+      const device = Auth.createDevice({ userId: username, deviceName: 'dev/' + username })
+      team.addForTesting(user, [], Auth.redactDevice(device))
+    }
+
+    //
+    // Invite new user and have them join
+    //
+
+    const { seed } = team.inviteMember({ maxUses: 1000 })
+
+    const username = 'new-user'
+    const user = Auth.createUser(username, username)
+    const device = Auth.createDevice({ userId: username, deviceName: 'laptop' })
+    const proofOfInvitation = Auth.generateProof(seed)
+
+    team.admitMember(proofOfInvitation, Auth.redactKeys(user.keys), user.userName)
+
+    const serializedGraph = team.save()
+    const teamKeyring = team.teamKeyring()
+    const team2 = new Auth.Team({ source: serializedGraph, context: { user, device }, teamKeyring })
+
+    team2.join(teamKeyring)
+  })
+})

--- a/packages/crdx/src/validator/validators.ts
+++ b/packages/crdx/src/validator/validators.ts
@@ -86,7 +86,7 @@ export const fail = (msg: string, args?: any) => {
 const memoizeFunctionMap = (source: ValidatorSet) => {
   const result = {} as ValidatorSet
   const memoizeResolver = (link: Link<any, any>, graph: Graph<any, any>) => {
-    return `${hash('memoize', link)}:${hash('memoize', graph)}`
+    return `${link.hash}:${graph.root}`
   }
 
   for (const key in source) result[key] = memoize(source[key], memoizeResolver)


### PR DESCRIPTION
The memoize cache key was based on a hash of the entire graph. This hash was being generated each time a link was validated. On my system, validating each link took around 100ms with a graph of around 2000 links. With this change it appears that validating each link takes less than 1ms.

Of course, we don't want cache key collisions. Do you think using `link.hash` and `graph.root` should be unique enough for the expected use cases?