### PR TITLE
crdx: Make getSuccessorHashes iterative

### DIFF
--- a/packages/crdx/src/graph/getSuccessors.ts
+++ b/packages/crdx/src/graph/getSuccessors.ts
@@ -7,9 +7,21 @@ import type { Action, Graph, Link } from './types.js'
 const memoizeResolver = (graph: Graph<any, any>, hash: Hash) => `${graph.head.join('')}:${hash}`
 
 export const getSuccessorHashes = memoize((graph: Graph<any, any>, hash: Hash): Hash[] => {
-  const children = getChildrenHashes(graph, hash)
-  const successors = children.flatMap(parent => getSuccessorHashes(graph, parent))
-  return uniq(children.concat(successors))
+  var children = [ ...getChildrenHashes(graph, hash) ]
+  let visited = new Set()
+
+  while (children.length > 0) {
+    var child = children.pop()
+
+    if (!visited.has(child)) {
+      visited.add(child)
+      for (const successor of getChildrenHashes(graph, child)) {
+        children.push(successor)
+      }
+    }
+  }
+
+  return Array.from(visited)
 }, memoizeResolver)
 
 /** Returns the set of successors of `link` (not including `link`) */


### PR DESCRIPTION
For a graph with only 1602 links, due to the recursion in the getSuccessorHashes function, I receive the following error:
```
RangeError: Maximum call stack size exceeded
    at memoized (file:///home/lucas/src/tryquiet/auth/demos/quiet-sandbox/node_modules/lodash-es/memoize.js:54:26)
    at getChildrenHashes (file:///home/lucas/src/tryquiet/auth/demos/quiet-sandbox/node_modules/@localfirst/crdx/dist/index.js:92:26)
    at file:///home/lucas/src/tryquiet/auth/demos/quiet-sandbox/node_modules/@localfirst/crdx/dist/index.js:144:20
    at memoized (file:///home/lucas/src/tryquiet/auth/demos/quiet-sandbox/node_modules/lodash-es/memoize.js:62:23)
    at file:///home/lucas/src/tryquiet/auth/demos/quiet-sandbox/node_modules/@localfirst/crdx/dist/index.js:145:51
    at Array.flatMap (<anonymous>)
    at file:///home/lucas/src/tryquiet/auth/demos/quiet-sandbox/node_modules/@localfirst/crdx/dist/index.js:145:31
    at memoized (file:///home/lucas/src/tryquiet/auth/demos/quiet-sandbox/node_modules/lodash-es/memoize.js:62:23)
    at file:///home/lucas/src/tryquiet/auth/demos/quiet-sandbox/node_modules/@localfirst/crdx/dist/index.js:145:51
    at Array.flatMap (<anonymous>)
```
So this PR turns getSuccessorHashes into an iterative implementation.

For a graph with about 1400 links: creating a team from a serialized graph takes about: 19086.841540008783 ms using the old function and 18275.27139799297 ms using the new function. So it seems like the new function is even a bit faster without memoization (on successive levels). But it's unclear how much the memoization would affect larger graphs because I can't test the original function without it throwing an error. I think there are other bigger performance issues that can be addressed first and we can always add memoization if necessary.
