### PR TITLE
auth: using deviceId instead of deviceName to identify a device

### DIFF
--- a/packages/auth/src/team/test/devices.test.ts
+++ b/packages/auth/src/team/test/devices.test.ts
@@ -1,4 +1,4 @@
-import { redactDevice } from 'index.js'
+import { createDevice, redactDevice } from 'index.js'
 import { setup as setupUsers } from 'util/testing/index.js'
 import { describe, expect, it } from 'vitest'
 
@@ -39,6 +39,26 @@ describe('Team', () => {
       }
 
       expect(tryToRemoveDevice).toThrowError()
+    })
+
+    it("doesn't remove other devices with the same name", () => {
+      const { alice } = setup()
+
+      // Alice already has a device called 'laptop'
+      const firstLaptop = alice.device
+      expect(firstLaptop.deviceName).toBe('laptop')
+      expect(alice.team.members(alice.userId).devices).toHaveLength(1)
+
+      // Alice adds a second device also called 'laptop'
+      const secondLaptop = createDevice({ userId: alice.userId, deviceName: 'laptop' })
+      alice.team.addForTesting(alice.user, [], redactDevice(secondLaptop))
+      expect(alice.team.members(alice.userId).devices).toHaveLength(2)
+
+      // Alice removes the first laptop
+      alice.team.removeDevice(alice.device.deviceId)
+
+      // The second laptop is still there
+      expect(alice.team.members(alice.userId).devices).toHaveLength(1)
     })
 
     it('deviceWasRemoved works as expected', () => {

--- a/packages/auth/src/team/transforms/removeDevice.ts
+++ b/packages/auth/src/team/transforms/removeDevice.ts
@@ -12,7 +12,7 @@ export const removeDevice =
       member.userId === userId
         ? {
             ...member,
-            devices: member.devices?.filter(d => d.deviceName !== removedDevice.deviceName),
+            devices: member.devices?.filter(d => d.deviceId !== removedDevice.deviceId),
           }
         : member
 

--- a/packages/auth/src/util/actionFingerprint.ts
+++ b/packages/auth/src/util/actionFingerprint.ts
@@ -25,7 +25,7 @@ export const actionFingerprint = (link: TeamLink) => {
       }
 
       case 'ADD_DEVICE': {
-        return action.payload.device.deviceName
+        return action.payload.device.deviceId
       }
 
       case 'REMOVE_DEVICE': {


### PR DESCRIPTION
I am in favour of the device name not having to be unique. In my application, I generate the device name from device information from UAParser. This can often lead to name collisions (same device type, same operating system).

I have noticed that when I remove a device, all devices with the same name are removed. I therefore suggest to always use the deviceId and not the deviceName to identify a device.