### PR TITLE
auth: ENCRYPTION_FAILURE during key negotiation after key rotation

### DIFF
--- a/packages/auth/src/connection/Connection.ts
+++ b/packages/auth/src/connection/Connection.ts
@@ -331,10 +331,10 @@ export class Connection extends EventEmitter<ConnectionEvents> {
         // SHARED SECRET NEGOTIATION
 
         sendSeed: assign(({ context }) => {
-          const { user, peer, seed = randomKeyBytes() } = context
+          const { device, theirDevice, seed = randomKeyBytes() } = context
 
-          const recipientPublicKey = peer!.keys.encryption
-          const senderSecretKey = user!.keys.encryption.secretKey
+          const recipientPublicKey = theirDevice!.keys.encryption
+          const senderSecretKey = device.keys.encryption.secretKey
 
           this.#log(`encrypting seed with key ${recipientPublicKey}`)
           const encryptedSeed = asymmetric.encryptBytes({
@@ -350,10 +350,10 @@ export class Connection extends EventEmitter<ConnectionEvents> {
         deriveSharedKey: assign(({ context, event }) => {
           assertEvent(event, 'SEED')
           const { encryptedSeed } = event.payload
-          const { seed, user, peer } = context
+          const { seed, device, theirDevice } = context
           const cipher = encryptedSeed
-          const senderPublicKey = peer!.keys.encryption
-          const recipientSecretKey = user!.keys.encryption.secretKey
+          const senderPublicKey = theirDevice!.keys.encryption
+          const recipientSecretKey = device.keys.encryption.secretKey
 
           // decrypt the seed they sent
           try {


### PR DESCRIPTION
Hi Herb!

I recently encountered an ENCRYPTION_FAILURE when I tried to connect my device with the server.
I realized that the server had encrypted the seed for negotiating a shared key with a newer generation of user keys that my device was not yet aware of. As a result, the device was unable to connect and therefore could not synchronize the team graph to receive the new keys and remained locked out.

So I wrote a test that reproduces the problem. It occurs when a user has at least three devices in the team graph, let's say a laptop, a phone and a tablet. If he uses the laptop to remove the phone, the user keys are rotated, but the tablet won't receive the new keys if it's offline during the removal. Since the laptop and the server have the latest user keys, but the tablet doesn't, it becomes unable to connect to the server because the server uses a newer generation of user keys for key negotiation than the tablet.

I am wondering if the problem could be solved by using device keys for key negotiation as device keys never rotate. I have tried it and it solves the problem, passes all tests and I assume it is equally secure. But I'm uneasy about what I don't know, such as your reasons for favoring user keys for shared key negotiation, or security issues or side effects that I'm unaware of.
What do you think?